### PR TITLE
Globally replace id placeholders for doubly nested associations

### DIFF
--- a/src/jquery.clone_form_template.js
+++ b/src/jquery.clone_form_template.js
@@ -18,19 +18,24 @@
 
   var placeholder = '-1';
   function update_attrs($element, identifier) {
+    var regex;
+
     if ($element.attr('id')) {
+      regex = new RegExp('_' + placeholder + '_', 'g');
       $element.attr('id',
-        $element.attr('id').replace('_' + placeholder + '_', '_' + identifier + '_')
+        $element.attr('id').replace(new RegExp('_' + placeholder + '_', 'g'), '_' + identifier + '_')
       );
     }
     if ($element.attr('for')) {
+      regex = new RegExp('_' + placeholder + '_', 'g');
       $element.attr('for',
-        $element.attr('for').replace('_' + placeholder + '_', '_' + identifier + '_')
+        $element.attr('for').replace(regex, '_' + identifier + '_')
       );
     }
     if ($element.attr('name')) {
+      regex = new RegExp('[' + placeholder + ']', 'g');
       $element.attr('name',
-        $element.attr('name').replace('[' + placeholder + ']', '[' + identifier + ']')
+        $element.attr('name').replace(regex, '[' + identifier + ']')
       );
     }
   }


### PR DESCRIPTION
Ran into an issue where we had a doubly nested form, and the placeholder that was set for the child index for the final level of the form wasn't being replaced with the dynamically generated id. This replaces all instances of the placeholder (globally) with the generated value of the id.
