### PR TITLE
Added livesearch:empty event, fired when the search input is cleared.

### DIFF
--- a/src/jquery.livesearch.js
+++ b/src/jquery.livesearch.js
@@ -104,7 +104,8 @@
 
     search: function () {
       var _this = this,
-        form_data = this.options.serialize.serialize();
+        form_data = this.options.serialize.serialize(),
+        value_length = this.$elem.val().length;
 
 
       if (this.options.process_data) {
@@ -114,8 +115,12 @@
         }
       }
 
+      if (value_length === 0) {
+        _this.$elem.trigger('livesearch:empty');
+      }
+
       if (form_data === this.last_search) { return; }
-      if (this.$elem.val().length < this.options.minimum_characters) { return; }
+      if (value_length < this.options.minimum_characters) { return; }
 
       if (this.search_xhr) {
         this.search_xhr.abort();

--- a/test/livesearch_test.js
+++ b/test/livesearch_test.js
@@ -224,4 +224,33 @@
     strictEqual(extension, 'json');
   });
 
+  test('fires livesearch:empty event on emptying the input', function() {
+    expect(1);
+    this.makeServer();
+    this.applyLivesearch();
+
+    var eventFired = false;
+    this.$input.on('livesearch:empty', function() {
+      eventFired = true;
+    });
+    this.type('123');
+    this.type('');
+
+    ok(eventFired);
+  });
+
+  test('does not fire livesearch:empty when searching for a non-empty string', function() {
+    expect(1);
+    this.makeServer();
+    this.applyLivesearch();
+
+    var eventNotFired = true;
+    this.$input.on('livesearch:empty', function() {
+      eventNotFired = false;
+    });
+    this.type('123');
+
+    ok(eventNotFired);
+  });
+
 }(jQuery));


### PR DESCRIPTION
I've added a livesearch:empty event, that fires when the search input is cleared. It makes it easier to do things when the user, well, clears the search input; for example, prompt him to input something, show a default page, or whatever. Previously, no event was fired in this case.

I hope it makes sense :)